### PR TITLE
Add REST API, hash table cache, and benchmarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@
 
 ## Overview
 
-Zu is a lightweight, fast command-line key-value store implemented in C that combines persistent disk storage with in-memory caching. It automatically caches items on their first access and maintains a fixed-size cache using LRU (Least Recently Used) eviction policy. All data is persistently stored in a local binary file, while frequently accessed items are kept in memory for faster retrieval.
+Zu is a lightweight, fast command-line key-value store implemented in C that combines persistent disk storage with an in-memory hash table for caching. It automatically caches items on their first access, using the hash table to provide near-instantaneous O(1) lookups for cached data. All data is persistently stored in a local binary file, while frequently accessed items are kept in memory for faster retrieval.
 
 ## Key Features
 
 - **Persistent Storage**: Data is automatically saved to and loaded from a binary file (`dump.zdb`)
-- **Memory Cache**: Items are cached on first access with LRU eviction when cache is full
+- **Fast In-Memory Lookups**: A hash table is used for the in-memory cache, providing O(1) average time complexity for lookups.
 - **Command-Line Interface**: Simple, intuitive commands for all operations
 - **Performance Monitoring**: Built-in execution time measurement for each operation
 - **Lightweight Design**: Minimal resource footprint with efficient C implementation
 
-## Commands
+
 
 | Command              | Description                                                 |
 | -------------------- | ----------------------------------------------------------- |
@@ -31,9 +31,21 @@ Zu is a lightweight, fast command-line key-value store implemented in C that com
 | `zall`               | List all stored key-value pairs                             |
 | `init_db`            | Initialize the database with random key-value pairs         |
 | `cache_status`       | Show current cache contents and usage statistics            |
+| `benchmark`          | Run performance benchmark                                   |
 | `clean`              | Clear the terminal screen                                   |
 | `help`               | Display available commands                                  |
 | `exit` / `quit`      | Exit the program                                            |
+
+## REST API Endpoints
+
+Zu also exposes a simple REST API for `set` and `get` operations. The server runs on port `1337` by default.
+
+### Endpoints
+
+| Endpoint             | Method | Description                                   | Parameters                                   | Example                                     |
+| -------------------- | ------ | --------------------------------------------- | -------------------------------------------- | ------------------------------------------- |
+| `/set`               | `GET`  | Store or update a key-value pair              | `key=<key>`, `value=<value>`                 | `http://localhost:1337/set?key=name&value=John%20Doe` |
+| `/get`               | `GET`  | Retrieve the value for a given key            | `key=<key>`                                  | `http://localhost:1337/get?key=name`        |
 
 ## Installation
 
@@ -147,12 +159,13 @@ This will build the test suite and run it.
 ## Roadmap
 
 - [ ] Support for different data types
-- [ ] Network interface (TCP/HTTP)
+
+- [X] REST API
 - [ ] Atomic operations and transactions
 - [X] Comprehensive test suite
-- [ ] Performance benchmarking tools
+- [X] Performance benchmarking tools
 - [ ] Data compression options
-- [ ] Hash tables for faster lookups
+- [X] Hash tables for faster lookups
 
 ## Contributing
 

--- a/src/cache.h
+++ b/src/cache.h
@@ -1,18 +1,17 @@
 #ifndef CACHE_H
 #define CACHE_H
 
-#include "ds.h"     // For DataItem
+#include "ds.h"     // For DataItem, HashTable
 #include <stddef.h> // For size_t
 
 // Extern declarations for global cache variables
-// Definitions will be in zu_cache.c
-extern DataItem *memory_cache;
-extern int cache_size;
-extern size_t cache_capacity;
+extern HashTable *memory_cache;
 
 // --- Cache Management Function Declarations ---
-void add_or_update_in_memory_cache(const char *key, const char *value);
-void remove_from_memory_cache(const char *key);
-int free_global_cache(void); // To free the cache at the end
+void init_cache(void);
+void free_cache(void);
+void add_to_cache(const char *key, const char *value);
+DataItem *get_from_cache(const char *key);
+void remove_from_cache(const char *key);
 
-#endif // ZU_CACHE_H
+#endif // CACHE_H

--- a/src/commands.c
+++ b/src/commands.c
@@ -9,158 +9,75 @@
 #include <stdlib.h>
 #include <time.h>
 
-/**
- * @brief Sets or updates a key-value pair in the database
- *
- * This function first checks if the database exists, then either:
- * - Appends a new key-value pair if the key doesn't exist
- * - Updates the value if the key already exists
- *
- * @param key_to_set The key to set or update
- * @param value_to_set The value to associate with the key
- * @return int Returns 1 on success, -1 on failure
- */
+#include "commands.h"
+#include "config.h"
+#include "ds.h"
+#include "cache.h"
+#include "io.h"
+#include "utils.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+
 int zset_command(const char *key_to_set, const char *value_to_set)
 {
-    // First ensure database exists
     if (!ensure_database_exists())
     {
-        return -1; // Database doesn't exist and user chose not to create it
-    }
-
-    char *old_value = NULL;
-    int result = find_key_on_disk(key_to_set, &old_value);
-
-    if (result < 0)
-    {
-        printf("Error: Could not access data for zset.\n");
         return -1;
     }
 
-    if (result == 0)
+    if (update_key_on_disk(key_to_set, value_to_set) < 0)
     {
-        // Key doesn't exist, append new key-value pair
-        if (append_key_to_disk(key_to_set, value_to_set) <= 0)
-        {
-            printf("Error: Failed to set new key.\n");
-            return -1;
-        }
-        printf("OK\n");
-        return 1;
-    }
-
-    // Key exists, update its value
-    if (old_value)
-    {
-        free(old_value); // Free the old value we got from find_key_on_disk
-    }
-
-    // Remove the old key-value pair
-    if (remove_key_from_disk(key_to_set) < 0)
-    {
-        printf("Error: Could not remove old key-value pair.\n");
+        printf("Error: Failed to set key.\n");
         return -1;
     }
 
-    // Add the new key-value pair
-    if (append_key_to_disk(key_to_set, value_to_set) <= 0)
-    {
-        printf("Error: Failed to update key.\n");
-        return -1;
-    }
-
+    add_to_cache(key_to_set, value_to_set);
     printf("OK\n");
     return 1;
 }
 
-/**
- * @brief Retrieves the value associated with a key
- *
- * This function implements a two-level lookup:
- * 1. First checks the in-memory cache
- * 2. If not found in cache, searches the disk database
- * If found on disk, the key-value pair is added to the cache
- *
- * @param key_to_get The key to look up
- * @return char* Returns a pointer to the value string if found, NULL otherwise.
- *               The returned string is owned by the cache and should not be freed by the caller
- */
 char *zget_command(const char *key_to_get)
 {
-    // Search in cache first
-    if (memory_cache == NULL)
+    DataItem *item = get_from_cache(key_to_get);
+    if (item)
     {
-        memory_cache = calloc(CACHE_SIZE, sizeof(DataItem));
-        if (!memory_cache)
-        {
-            printf("Error: Failed to allocate memory cache\n");
-            return NULL;
-        }
+#ifndef BENCHMARK_MODE
+        printf("%s\n", item->value);
+#endif
+        return my_strdup(item->value);
     }
 
-    for (int i = 0; i < cache_size; i++)
-    {
-        if (memory_cache[i].key && strcmp(memory_cache[i].key, key_to_get) == 0)
-        {
-            memory_cache[i].hit_count++;                // Increment hit count
-            memory_cache[i].last_accessed = time(NULL); // Update last accessed time
-            printf("%s\n", memory_cache[i].value);
-            return memory_cache[i].value;
-        }
-    }
-
-    // Not in cache, search on disk
     char *value = NULL;
     int result = find_key_on_disk(key_to_get, &value);
 
     if (result < 0)
     {
+#ifndef BENCHMARK_MODE
         printf("Error: Could not access data.\n");
+#endif
         return NULL;
     }
     else if (result == 0)
     {
+#ifndef BENCHMARK_MODE
         printf("Key '%s' not found.\n", key_to_get);
+#endif
         return NULL;
     }
 
-    // Make a copy of the value before adding to cache
-    char *value_copy = my_strdup(value);
-    if (!value_copy)
-    {
-        printf("Error: Failed to allocate memory for value copy.\n");
-        free(value);
-        return NULL;
-    }
-
-    // Add to cache using the copy
-    add_or_update_in_memory_cache(key_to_get, value_copy);
-
-    // Print the value
-    printf("%s\n", value_copy);
-
-    // Now we can safely free the original value
-    free(value);
-    // Note: value_copy is now owned by the cache and will be freed when the cache is cleared
-    return value_copy;
+    add_to_cache(key_to_get, value);
+#ifndef BENCHMARK_MODE
+    printf("%s\n", value);
+#endif
+    return value;
 }
 
-/**
- * @brief Removes a key-value pair from both cache and disk
- *
- * This function removes the specified key-value pair from:
- * 1. The in-memory cache (if present)
- * 2. The disk database
- *
- * @param key_to_remove The key to remove
- * @return int Returns 1 if key was found and removed, 0 if key not found, -1 on error
- */
 int zrm_command(const char *key_to_remove)
 {
-    // Remove from cache if present
-    remove_from_memory_cache(key_to_remove);
+    remove_from_cache(key_to_remove);
 
-    // Remove from disk
     int result = remove_key_from_disk(key_to_remove);
 
     if (result < 0)
@@ -180,18 +97,10 @@ int zrm_command(const char *key_to_remove)
     }
 }
 
-/**
- * @brief Lists all key-value pairs in the database
- *
- * This function reads and prints all key-value pairs stored in the disk database.
- * The output format is one key-value pair per line.
- *
- * @return int Returns 1 if successful, -1 if database is empty or on error
- */
 int zall_command()
 {
     int result = print_all_data_from_disk();
-    if (result <= 0) // Changed from == 0 to <= 0 to handle both empty and error cases
+    if (result <= 0)
     {
         printf("(empty or file error)\n");
         return -1;
@@ -199,27 +108,14 @@ int zall_command()
     return 1;
 }
 
-/**
- * @brief Initializes the database with random key-value pairs
- *
- * This function creates a new database file and populates it with
- * INIT_DB_SIZE random key-value pairs. Each key and value is a
- * random alphanumeric string with length between MIN_LENGTH and MAX_LENGTH.
- *
- * @return int Returns 1 on successful initialization, -1 on error
- */
 int init_db_command()
 {
-    // Initialize random number generator with current time
     srand(time(NULL));
-
-    // Define min and max lengths for keys and values
-    const int MIN_LENGTH = 4;  // Minimum length for readability
-    const int MAX_LENGTH = 64; // Maximum length to keep things reasonable
+    const int MIN_LENGTH = 4;
+    const int MAX_LENGTH = 64;
 
     printf("Initializing database with %d random key-value pairs...\n", INIT_DB_SIZE);
 
-    // Open file in write mode to start fresh
     FILE *file = fopen(FILENAME, "wb");
     if (!file)
     {
@@ -229,13 +125,11 @@ int init_db_command()
 
     for (int i = 0; i < INIT_DB_SIZE; i++)
     {
-        // Generate random lengths for this pair
         int key_length = MIN_LENGTH + (rand() % (MAX_LENGTH - MIN_LENGTH + 1));
         int value_length = MIN_LENGTH + (rand() % (MAX_LENGTH - MIN_LENGTH + 1));
 
-        // Allocate buffers with the random lengths
-        char *buffer_key = malloc(key_length + 1);     // +1 for null terminator
-        char *buffer_value = malloc(value_length + 1); // +1 for null terminator
+        char *buffer_key = malloc(key_length + 1);
+        char *buffer_value = malloc(value_length + 1);
 
         if (!buffer_key || !buffer_value)
         {
@@ -246,11 +140,9 @@ int init_db_command()
             return -1;
         }
 
-        // Generate random strings of the chosen lengths
         generate_random_alphanumeric(buffer_key, key_length);
         generate_random_alphanumeric(buffer_value, value_length);
 
-        // Write directly to file
         if (!write_item_to_file(file, buffer_key, buffer_value))
         {
             printf("Error: Failed to write key-value pair to file.\n");
@@ -263,7 +155,6 @@ int init_db_command()
         printf("Inserted item %d / %d (key length: %d, value length: %d)\n",
                i + 1, INIT_DB_SIZE, key_length, value_length);
 
-        // Free the temporary buffers
         free(buffer_key);
         free(buffer_value);
     }
@@ -273,16 +164,6 @@ int init_db_command()
     return 1;
 }
 
-/**
- * @brief Displays the current status of the in-memory cache
- *
- * This function prints detailed information about the cache including:
- * - Total number of items in cache
- * - For each cached item: key, value, hit count, and last access time
- *
- * @return int Returns 1 if cache is initialized and status is displayed,
- *             -1 if cache is not initialized
- */
 int cache_status(void)
 {
     if (!memory_cache)
@@ -291,25 +172,81 @@ int cache_status(void)
         return -1;
     }
 
-    printf("Cache status: %d/%d items used\n", cache_size, CACHE_SIZE);
-    for (int i = 0; i < cache_size; i++)
+    printf("Cache status: %d items used\n", memory_cache->size);
+    for (unsigned int i = 0; i < memory_cache->size; i++)
     {
-        if (memory_cache[i].key)
+        DataItem *item = memory_cache->table[i];
+        while (item)
         {
-            printf("  [%d] Key: %s, Value: %s, Hits: %u, Last accessed: %u\n",
-                   i, memory_cache[i].key, memory_cache[i].value,
-                   memory_cache[i].hit_count, memory_cache[i].last_accessed);
+            printf("  Key: %s, Value: %s, Hits: %u, Last accessed: %u\n",
+                   item->key, item->value, item->hit_count, item->last_accessed);
+            item = item->next;
         }
     }
     return 1;
 }
 
-/**
- * @brief Clears the terminal screen
- *
- * This function uses ANSI escape codes to clear the terminal screen.
- */
+#include "io_benchmark.h"
+
 void clear(void)
 {
-    printf("\33[H\33[J"); // Clear the terminal screen
+    printf("\33[H\33[J");
+}
+
+int benchmark_command(void)
+{
+    printf("Starting benchmark with %d key-value pairs...\n", BENCHMARK_DB_SIZE);
+
+    const char *benchmark_filename = "benchmark.zdb";
+    double init_time, get_time;
+    struct timespec start, end;
+
+    // 1. Initialize temporary database
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    if (init_benchmark_db(benchmark_filename, BENCHMARK_DB_SIZE) != 0)
+    {
+        printf("Error: Failed to initialize benchmark database.\n");
+        return -1;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    init_time = (end.tv_sec - start.tv_sec) * 1000.0 + (end.tv_nsec - start.tv_nsec) / 1000000.0;
+    printf("Database initialization complete in %.3fms\n", init_time);
+
+    // 2. Get all keys from the benchmark database
+    int num_keys = 0;
+    char **keys = get_all_keys_from_benchmark_db(benchmark_filename, &num_keys);
+    if (!keys || num_keys == 0)
+    {
+        printf("Error: No keys found in benchmark database.\n");
+        cleanup_benchmark_db(benchmark_filename);
+        return -1;
+    }
+
+    // 3. Perform zget operations and measure time
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    for (int i = 0; i < num_keys; i++)
+    {
+        char *value = zget_command(keys[i]);
+        if (value) free(value); // Free the copied value from zget_command
+    }
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    get_time = (end.tv_sec - start.tv_sec) * 1000.0 + (end.tv_nsec - start.tv_nsec) / 1000000.0;
+
+    printf("\nBenchmark Results:\n");
+    printf("Total GET operations: %d\n", num_keys);
+    printf("Total GET time: %.3fms\n", get_time);
+    printf("Average GET time per key: %.3fus\n", (get_time * 1000.0) / num_keys);
+
+    // Clean up keys array
+    for (int i = 0; i < num_keys; i++)
+    {
+        free(keys[i]);
+    }
+    free(keys);
+
+    // 4. Clean up temporary database
+    cleanup_benchmark_db(benchmark_filename);
+    printf("Benchmark database cleaned up.\n");
+
+    return 0;
 }

--- a/src/commands.h
+++ b/src/commands.h
@@ -9,4 +9,6 @@ int init_db_command(void);
 int cache_status(void);
 void clear(void);
 
+int benchmark_command(void);
+
 #endif // COMMANDS_H

--- a/src/config.h
+++ b/src/config.h
@@ -1,12 +1,14 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-
 #define INITIAL_CAPACITY 10
-#define INIT_DB_SIZE 5
+#define INIT_DB_SIZE 5000
+#define BENCHMARK_DB_SIZE 100000 // Number of key-value pairs for benchmark
 #define CACHE_SIZE 1000
 #define CACHE_TTL 60
-extern char* FILENAME;
+#define REST_SERVER_PORT 1337
+#define BENCHMARK_MODE 1 // Set to 1 to suppress output during benchmark
+extern char *FILENAME;
 
 void set_test_mode(void);
 

--- a/src/ds.h
+++ b/src/ds.h
@@ -4,13 +4,28 @@
 #include <stdlib.h> // For size_t
 
 // --- Data Structures ---
-typedef struct
+typedef struct DataItem
 {
     char *key;
     char *value;
     unsigned int hit_count;     // Hit count for caching
     unsigned int last_accessed; // Timestamp of last access
+    struct DataItem *next;      // For chaining in hash table
 } DataItem;
+
+typedef struct
+{
+    unsigned int size;
+    DataItem **table;
+} HashTable;
+
+// --- Hash Table Function Declarations ---
+HashTable *create_hash_table(unsigned int size);
+void free_hash_table(HashTable *ht);
+unsigned int hash_function(const char *key, unsigned int size);
+void hash_table_insert(HashTable *ht, const char *key, const char *value);
+DataItem *hash_table_search(HashTable *ht, const char *key);
+void hash_table_remove(HashTable *ht, const char *key);
 
 // --- Helper Function Declarations ---
 char *my_strdup(const char *s);

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -1,0 +1,177 @@
+#include "http_server.h"
+#include "commands.h"
+#include "cache.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <unistd.h>
+
+#include "config.h"
+#define PORT REST_SERVER_PORT
+#define BUFFER_SIZE 1024
+
+// Function to parse URL-encoded key-value pairs
+static void parse_query_params(char *query, char *key_buf, char *value_buf)
+{
+    char *token;
+    char *rest = query; // Use a temporary pointer for strtok_r
+
+    // Initialize buffers to empty strings
+    key_buf[0] = '\0';
+    value_buf[0] = '\0';
+
+    // Iterate through parameters separated by '&'
+    while ((token = strtok_r(rest, "&", &rest)))
+    {
+        char *equals = strchr(token, '=');
+        if (equals)
+        {
+            *equals = '\0'; // Null-terminate the parameter name
+            char *param_name = token;
+            char *param_value = equals + 1;
+
+            if (strcmp(param_name, "key") == 0)
+            {
+                strcpy(key_buf, param_value);
+            }
+            else if (strcmp(param_name, "value") == 0)
+            {
+                strcpy(value_buf, param_value);
+            }
+        }
+    }
+}
+
+// Function to handle client requests
+void handle_client(int client_socket)
+{
+    char buffer[BUFFER_SIZE] = {0};
+    read(client_socket, buffer, BUFFER_SIZE);
+
+    // Simple HTTP request parsing
+    char *method = strtok(buffer, " ");
+    char *uri = strtok(NULL, " ");
+
+    if (method && uri)
+    {
+        char *path = strtok(uri, "?");
+        char *query = strtok(NULL, "");
+
+        if (strcmp(path, "/set") == 0)
+        {
+            char key[256] = {0}, value[256] = {0};
+            if (query)
+            {
+                parse_query_params(query, key, value);
+            }
+
+            if (strlen(key) > 0 && strlen(value) > 0)
+            {
+                int result = zset_command(key, value);
+                if (result == 1)
+                {
+                    char *response = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{\"status\":\"OK\"}";
+                    send(client_socket, response, strlen(response), 0);
+                }
+                else
+                {
+                    char *response = "HTTP/1.1 500 Internal Server Error\r\nContent-Type: application/json\r\n\r\n{\"status\":\"Error setting key\"}";
+                    send(client_socket, response, strlen(response), 0);
+                }
+            }
+            else
+            {
+                char *response = "HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\n\r\n{\"status\":\"Missing key or value\"}";
+                send(client_socket, response, strlen(response), 0);
+            }
+        }
+        else if (strcmp(path, "/get") == 0)
+        {
+            char key[256] = {0}, dummy_value[256] = {0}; // dummy_value to match parse_query_params signature
+            if (query)
+            {
+                parse_query_params(query, key, dummy_value);
+            }
+
+            if (strlen(key) > 0)
+            {
+                char *result = zget_command(key);
+                if (result != NULL)
+                {
+                    char response[BUFFER_SIZE];
+                    snprintf(response, BUFFER_SIZE, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{\"status\":\"OK\", \"value\":\"%s\"}", result);
+                    send(client_socket, response, strlen(response), 0);
+                    free(result); // zget_command returns a malloc'd string
+                }
+                else
+                {
+                    char *response = "HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\n\r\n{\"status\":\"Key not found\"}";
+                    send(client_socket, response, strlen(response), 0);
+                }
+            }
+        }
+        else if (strcmp(path, "/health") == 0)
+        {
+            char *response = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{\"status\":\"healthy\"}";
+            send(client_socket, response, strlen(response), 0);
+        }
+        else
+        {
+            char *response = "HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\n\r\n{\"status\":\"Missing key\"}";
+            send(client_socket, response, strlen(response), 0);
+        }
+    }
+    else
+    {
+        char *response = "HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\n\r\n{\"status\":\"Not Found\"}";
+        send(client_socket, response, strlen(response), 0);
+    }
+
+    close(client_socket);
+}
+
+void start_inhouse_rest_server(void)
+{
+    int server_fd, client_socket;
+    struct sockaddr_in address;
+    int addrlen = sizeof(address);
+
+    init_cache(); // Ensure cache is initialized for zget/zset
+
+    // Creating socket file descriptor
+    if ((server_fd = socket(AF_INET, SOCK_STREAM, 0)) == 0)
+    {
+        perror("socket failed");
+        exit(EXIT_FAILURE);
+    }
+
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = INADDR_ANY;
+    address.sin_port = htons(PORT);
+
+    // Forcefully attaching socket to the port 1337
+    if (bind(server_fd, (struct sockaddr *)&address, sizeof(address)) < 0)
+    {
+        perror("bind failed");
+        exit(EXIT_FAILURE);
+    }
+    if (listen(server_fd, 10) < 0)
+    {
+        perror("listen");
+        exit(EXIT_FAILURE);
+    }
+
+    printf("Starting in-house REST server on port %d\n", PORT);
+
+    while (1)
+    {
+        if ((client_socket = accept(server_fd, (struct sockaddr *)&address, (socklen_t *)&addrlen)) < 0)
+        {
+            perror("accept");
+            exit(EXIT_FAILURE);
+        }
+        handle_client(client_socket);
+    }
+}

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -1,0 +1,6 @@
+#ifndef HTTP_SERVER_H
+#define HTTP_SERVER_H
+
+void start_inhouse_rest_server(void);
+
+#endif // HTTP_SERVER_H

--- a/src/io.h
+++ b/src/io.h
@@ -20,5 +20,6 @@ int ensure_database_exists(void); // New function to check/create database
 
 // Helper function declarations
 int write_item_to_file(FILE *file, const char *key, const char *value);
+int read_item_from_file(FILE *file, char **key, char **value);
 
 #endif // ZU_IO_H

--- a/src/io_benchmark.c
+++ b/src/io_benchmark.c
@@ -1,0 +1,156 @@
+#include "io_benchmark.h"
+#include "io.h"
+#include "utils.h"
+#include "config.h"
+#include "ds.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+// Helper function to write a single item to a specified file
+static int write_item_to_benchmark_file(FILE *file, const char *key, const char *value) {
+    // Re-using the write_item_to_file from io.h
+    return write_item_to_file(file, key, value);
+}
+
+// Helper function to read a single item from a specified file
+static int read_item_from_benchmark_file(FILE *file, char **key, char **value) {
+    // Re-using the read_item_from_file from io.h
+    return read_item_from_file(file, key, value);
+}
+
+int init_benchmark_db(const char *filename, int num_entries)
+{
+    srand(time(NULL));
+    const int MIN_LENGTH = 4;
+    const int MAX_LENGTH = 64;
+
+    FILE *file = fopen(filename, "wb");
+    if (!file)
+    {
+        perror("Error opening benchmark database file for writing");
+        return -1;
+    }
+
+    for (int i = 0; i < num_entries; i++)
+    {
+        int key_length = MIN_LENGTH + (rand() % (MAX_LENGTH - MIN_LENGTH + 1));
+        int value_length = MIN_LENGTH + (rand() % (MAX_LENGTH - MIN_LENGTH + 1));
+
+        char *buffer_key = malloc(key_length + 1);
+        char *buffer_value = malloc(value_length + 1);
+
+        if (!buffer_key || !buffer_value)
+        {
+            perror("Failed to allocate memory for benchmark key-value pair");
+            free(buffer_key);
+            free(buffer_value);
+            fclose(file);
+            return -1;
+        }
+
+        generate_random_alphanumeric(buffer_key, key_length);
+        generate_random_alphanumeric(buffer_value, value_length);
+
+        if (!write_item_to_benchmark_file(file, buffer_key, buffer_value))
+        {
+            perror("Failed to write benchmark key-value pair to file");
+            free(buffer_key);
+            free(buffer_value);
+            fclose(file);
+            return -1;
+        }
+
+        free(buffer_key);
+        free(buffer_value);
+    }
+
+    fclose(file);
+    return 0;
+}
+
+char *find_key_in_benchmark_db(const char *filename, const char *key)
+{
+    FILE *file = fopen(filename, "rb");
+    if (!file)
+    {
+        return NULL; // File error or not found
+    }
+
+    char *current_key = NULL;
+    char *current_value = NULL;
+    char *found_value = NULL;
+
+    while (read_item_from_benchmark_file(file, &current_key, &current_value) > 0)
+    {
+        if (strcmp(current_key, key) == 0)
+        {
+            found_value = my_strdup(current_value);
+            free(current_key);
+            free(current_value);
+            break;
+        }
+        free(current_key);
+        free(current_value);
+    }
+
+    fclose(file);
+    return found_value;
+}
+
+char **get_all_keys_from_benchmark_db(const char *filename, int *num_keys)
+{
+    FILE *file = fopen(filename, "rb");
+    if (!file)
+    {
+        *num_keys = 0;
+        return NULL;
+    }
+
+    char **keys = NULL;
+    int count = 0;
+    int capacity = 10;
+    keys = malloc(sizeof(char *) * capacity);
+    if (!keys) {
+        perror("Failed to allocate memory for keys");
+        *num_keys = 0;
+        fclose(file);
+        return NULL;
+    }
+
+    char *current_key = NULL;
+    char *current_value = NULL;
+
+    while (read_item_from_benchmark_file(file, &current_key, &current_value) > 0)
+    {
+        if (count >= capacity) {
+            capacity *= 2;
+            keys = realloc(keys, sizeof(char *) * capacity);
+            if (!keys) {
+                perror("Failed to reallocate memory for keys");
+                // Free already allocated keys
+                for (int i = 0; i < count; i++) {
+                    free(keys[i]);
+                }
+                *num_keys = 0;
+                fclose(file);
+                return NULL;
+            }
+        }
+        keys[count++] = my_strdup(current_key);
+        free(current_key);
+        free(current_value);
+    }
+
+    fclose(file);
+    *num_keys = count;
+    return keys;
+}
+
+void cleanup_benchmark_db(const char *filename)
+{
+    unlink(filename);
+}

--- a/src/io_benchmark.h
+++ b/src/io_benchmark.h
@@ -1,0 +1,18 @@
+#ifndef IO_BENCHMARK_H
+#define IO_BENCHMARK_H
+
+#include <stdio.h>
+
+// Function to initialize a temporary database for benchmarking
+int init_benchmark_db(const char *filename, int num_entries);
+
+// Function to find a key in the benchmark database
+char *find_key_in_benchmark_db(const char *filename, const char *key);
+
+// Function to get all keys from the benchmark database
+char **get_all_keys_from_benchmark_db(const char *filename, int *num_keys);
+
+// Function to clean up the benchmark database
+void cleanup_benchmark_db(const char *filename);
+
+#endif // IO_BENCHMARK_H

--- a/src/version.c
+++ b/src/version.c
@@ -1,3 +1,3 @@
 #include "version.h"
 
-char ZU_VERSION[] = "v0.2.0-alpha"; 
+char ZU_VERSION[] = "v0.3.0-alpha";

--- a/tests/test.c
+++ b/tests/test.c
@@ -66,15 +66,8 @@ static void test_cache_operations(void) {
     assert(strcmp(zget_command("cache_key"), "cache_value") == 0);
     
     // Verify it's in cache
-    int found = 0;
-    for (int i = 0; i < cache_size; i++) {
-        if (memory_cache[i].key && strcmp(memory_cache[i].key, "cache_key") == 0) {
-            test_cond(strcmp(memory_cache[i].value, "cache_value") == 0);
-            found = 1;
-            break;
-        }
-    }
-    if (!found) { test_cond(0); }
+    DataItem *item = get_from_cache("cache_key");
+    test_cond(item != NULL && strcmp(item->value, "cache_value") == 0);
 }
 
 // Test removal operation
@@ -140,7 +133,7 @@ static void test_cache_status(void) {
     assert(result == 1);
     
     // Test with uninitialized cache
-    assert(free_global_cache() == 1);
+    free_cache();
     assert(cache_status() == -1);
     test_cond(result);
 }
@@ -162,6 +155,8 @@ static void test_db_init(void) {
 int main(void) {
     printf("\n=== Zu Test Suite ===\n\n");
     set_test_mode();
+    init_cache();
+
     
     // Run all tests
     test_basic_operations();


### PR DESCRIPTION
Introduces a REST API server for set/get operations, implements a hash table for the in-memory cache, and adds a performance benchmarking command. Updates the cache logic to use the new hash table structure, refactors related code, and updates documentation to reflect these features. Also includes new files for the HTTP server and benchmarking utilities, and updates the version to v0.3.0-alpha.