### PR TITLE
[deft-security] Fix CWE-787: Out-of-bounds Write in src/utils.c

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -17,5 +17,5 @@ void generate_random_alphanumeric(char *str, size_t length) {
         int key = rand() % charset_size; // Generate a random index into the charset
         str[i] = charset[key];
     }
-    str[length] = '\0'; // Null-terminate the string
-}
+    if (length > 0) { str[length - 1] = '\0'; } else { str[0] = '\0'; }
+// Handle zero-length case separately to avoid negative indexing}


### PR DESCRIPTION
## Security Fix

**Vulnerability**: CWE-787: Out-of-bounds Write
**Severity**: HIGH
**File**: `src/utils.c`
**Confidence**: 0%

### Description
The function writes a null terminator at str[length], which exceeds the buffer if the caller provided exactly length bytes. This causes an out-of-bounds write vulnerability (CWE-787).

### Changes
This PR replaces the vulnerable code with a secure implementation.

---
*Automated by [deft.is](https://deft.is) code scanning*