### PR TITLE
[deft-security] Fix CWE-787: Out-of-bounds Write in src/utils.c

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -17,5 +17,5 @@ void generate_random_alphanumeric(char *str, size_t length) {
         int key = rand() % charset_size; // Generate a random index into the charset
         str[i] = charset[key];
     }
-    str[length] = '\0'; // Null-terminate the string
+    if (length > 0) { str[length - 1] = '\0'; } else { str[0] = '\0'; } // Null-terminate the string
 }


### PR DESCRIPTION
## Security Fix

**Vulnerability**: CWE-787: Out-of-bounds Write
**Severity**: HIGH
**File**: `src/utils.c`
**Confidence**: 0%

### Description
The loop writes to str[length], which is one past the buffer's end when length > 0. This causes an out-of-bounds write vulnerability.

### Changes
This PR replaces the vulnerable code with a secure implementation.

---
*Automated by [deft.is](https://deft.is) code scanning*