### PR TITLE
[deft-security] Fix CWE-476: NULL Pointer Dereference in tests/test.c

### DIFF
--- a/tests/test.c
+++ b/tests/test.c
@@ -130,7 +130,7 @@ static void test_cache_status(void) {
     assert(result == CMD_SUCCESS);
     char* value;
     assert(zget_command("status_key", &value) == CMD_SUCCESS);
-    assert(strcmp(value, "status_value") == 0);
+    assert(value != NULL && strcmp(value, "status_value") == 0);
     free(value);
     
     // Check cache status


### PR DESCRIPTION
## Security Fix

**Vulnerability**: CWE-476: NULL Pointer Dereference
**Severity**: MEDIUM
**File**: `tests/test.c`
**Confidence**: 80%

### Description
The value pointer from zget_command is used with strcmp without checking if it's NULL first. If zget_command succeeds but returns NULL (edge case), this will cause a crash.

### Changes
This PR replaces the vulnerable code with a secure implementation.

---
*Automated by [deft.is](https://deft.is) code scanning*