### PR TITLE
[deft-security] Fix CWE-120: Buffer Copy without Checking Size of Input in src/io.c

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -764,10 +764,20 @@ int ensure_database_exists(void) {
 
     // Database doesn't exist, ask user
     printf("Database does not exist. Create empty database? (YES/NO): ");
-    char response[10];
+    char response[256];
     if (!fgets(response, sizeof(response), stdin)) {
         pthread_mutex_unlock(&file_mutex);
         return 0;  // Error reading input
+    }
+    // Check if input was truncated
+    size_t len = strlen(response);
+    if (len > 0 && response[len-1] != '\n' && !feof(stdin)) {
+        // Input was truncated, clear the rest
+        int c;
+        while ((c = getchar()) != '\n' && c != EOF);
+        printf("Input too long. Database creation cancelled.\n");
+        pthread_mutex_unlock(&file_mutex);
+        return 0;
     }
 
     // Remove newline if present


### PR DESCRIPTION
## Security Fix

**Vulnerability**: CWE-120: Buffer Copy without Checking Size of Input
**Severity**: MEDIUM
**File**: `src/io.c`
**Confidence**: 75%

### Description
In ensure_database_exists, fgets reads into a fixed 10-byte buffer. If the user enters a very long response, it will be truncated, but the code doesn't validate this. An attacker could potentially cause unexpected behavior by providing input that gets truncated in a way that matches 'YES'.

### Changes
This PR replaces the vulnerable code with a secure implementation.

---
*Automated by [deft.is](https://deft.is) code scanning*