### PR TITLE
[deft-security] Fix CWE-400: Uncontrolled Resource Consumption in src/http_server.c

### DIFF
--- a/src/http_server.c
+++ b/src/http_server.c
@@ -453,7 +453,18 @@ void handle_client(int client_socket)
 
                     if (result == CMD_SUCCESS && result_value != NULL) {
                         // Dynamically allocate response body to handle large values
-                        size_t response_size = strlen(result_value) + 100; // Extra space for JSON structure
+                        size_t value_len = strlen(result_value);
+                        if (value_len > MAX_VALUE_LENGTH) {
+                            send_response(client_socket, 500, "Internal Server Error", "{\"error\":\"Value too large\"}");
+                            free(result_value);
+                            free(key);
+                            if (dummy_value) free(dummy_value);
+                            free(buffer);
+                            free(header_buffer);
+                            close(client_socket);
+                            return;
+                        }
+                        size_t response_size = value_len * 2 + 200; // Account for escaping + JSON structure // Extra space for JSON structure
                         char *response_body = malloc(response_size);
                         if (response_body) {
                             snprintf(response_body, response_size, "{\"value\":\"%s\"}", result_value);


### PR DESCRIPTION
## Security Fix

**Vulnerability**: CWE-400: Uncontrolled Resource Consumption
**Severity**: MEDIUM
**File**: `src/http_server.c`
**Confidence**: 72%

### Description
The response_size calculation adds only 100 bytes for JSON structure, but if result_value is near MAX_VALUE_LENGTH (4096), the total response could exceed safe limits. Additionally, no check ensures result_value length doesn't cause integer overflow in size calculation.

### Changes
This PR replaces the vulnerable code with a secure implementation.

---
*Automated by [deft.is](https://deft.is) code scanning*