### PR TITLE
[deft-security] Fix CWE-835: Loop with Unreachable Exit Condition ('Infinite Loop') in src/ds.c

### DIFF
--- a/src/ds.c
+++ b/src/ds.c
@@ -117,33 +117,36 @@ void hash_table_insert(HashTable *ht, const char *key, const char *value)
     const unsigned int max_evictions = CACHE_SIZE * 2; // Safety limit
 
     while (current_items > CACHE_SIZE && eviction_attempts < max_evictions) {
-        // Find LRU (lowest last_accessed) - avoid infinite loops
         DataItem *lru = NULL;
         unsigned int lru_time = UINT_MAX;
+        unsigned int lru_index = 0;
 
-        // Scan hash table to find LRU item
         for (unsigned int i = 0; i < ht->size; i++) {
             DataItem *item = ht->table[i];
             while (item) {
                 if (item->last_accessed < lru_time) {
                     lru_time = item->last_accessed;
                     lru = item;
-                } else if (item->last_accessed == lru_time && item < lru) {
-                    // Tie-breaker: prefer lower memory address to avoid loops
-                    lru = item;
+                    lru_index = i;
                 }
                 item = item->next;
             }
         }
 
         if (lru && lru->key) {
-            // Attempt to remove the LRU item
-            hash_table_remove(ht, lru->key);
+            char *key_copy = my_strdup(lru->key);
+            if (!key_copy) break;
+            unsigned int items_before = current_items;
+            hash_table_remove(ht, key_copy);
+            free(key_copy);
+            // Verify removal actually happened
+            if (hash_table_search(ht, lru->key) != NULL) {
+                break; // Removal failed, exit to prevent infinite loop
+            }
             current_items--;
             cached_item_count = current_items;
             eviction_attempts++;
         } else {
-            // No removable items found, break to prevent infinite loop
             break;
         }
     }


### PR DESCRIPTION
## Security Fix

**Vulnerability**: CWE-835: Loop with Unreachable Exit Condition ('Infinite Loop')
**Severity**: MEDIUM
**File**: `src/ds.c`
**Confidence**: 75%

### Description
While the code attempts to prevent infinite loops with max_evictions, the LRU eviction logic can still fail to make progress if hash_table_remove() doesn't actually remove items (e.g., due to bugs or race conditions). The tie-breaker using pointer comparison (item < lru) is non-deterministic and may not prevent loops if the same item is repeatedly selected.

### Changes
This PR replaces the vulnerable code with a secure implementation.

---
*Automated by [deft.is](https://deft.is) code scanning*