### PR TITLE
[deft-security] Fix 7 vulnerabilities in tests/test.c

### DIFF
--- a/tests/test.c
+++ b/tests/test.c
@@ -12,20 +12,25 @@
 
 /* The following lines make up our testing "framework" :) */
 static int tests = 0, fails = 0, skips = 0;
-#define test(_s) { printf("#%02d ", ++tests); printf(_s); }
+#define test(_s) { printf("#%02d ", ++tests); printf("%s", _s); }
 #define test_cond(_c) do { if(_c) { printf("\033[0;32mPASSED\033[0;0m\n\n"); } else { printf("\033[0;31mFAILED\033[0;0m\n\n"); fails++; } } while(0)
 #define test_skipped() { printf("\033[01;33mSKIPPED\033[0;0m\n\n"); skips++; }
 
 
 // Helper function to clean up test database
 static void cleanup_test_db(void) {
-    unlink(FILENAME);
+    // Verify FILENAME is in a safe test directory
+    if (strstr(FILENAME, "/tmp/") == FILENAME || strstr(FILENAME, "./test_") == FILENAME) {
+        if (unlink(FILENAME) == -1 && errno != ENOENT) {
+        perror("Warning: Failed to delete test database");
+    }
+    }
 }
 
 // Helper function to initialize test database
 static void init_test_db(void) {
     // Create an empty database file
-    int fd = open(FILENAME, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    int fd = open(FILENAME, O_WRONLY | O_CREAT | O_TRUNC, 0600);
     if (fd == -1) {
         perror("Failed to create test database file");
         exit(1);
@@ -67,7 +72,10 @@ static void test_cache_operations(void) {
     char* get_result;
     assert(zget_command("cache_key", &get_result) == CMD_SUCCESS);
     assert(strcmp(get_result, "cache_value") == 0);
-    free(get_result);
+    if (get_result) {
+        free(get_result);
+        get_result = NULL;
+    }
     
     // Verify it's in cache
     DataItem *item = get_from_cache("cache_key");
@@ -130,7 +138,7 @@ static void test_cache_status(void) {
     assert(result == CMD_SUCCESS);
     char* value;
     assert(zget_command("status_key", &value) == CMD_SUCCESS);
-    assert(strcmp(value, "status_value") == 0);
+    assert(value != NULL && strcmp(value, "status_value") == 0);
     free(value);
     
     // Check cache status
@@ -139,6 +147,7 @@ static void test_cache_status(void) {
     
     // Test with uninitialized cache
     free_cache();
+    init_cache(); // Re-initialize for subsequent operations
     assert(cache_status() == CMD_ERROR);
     test_cond(result == CMD_SUCCESS);
 }


### PR DESCRIPTION
## Security Fixes

**File**: `tests/test.c`
**Highest Severity**: MEDIUM
**Fixes Applied**: 7

### CWE-476: NULL Pointer Dereference
- **Severity**: MEDIUM
- **Confidence**: 80%
- The value pointer from zget_command is used with strcmp without checking if it's NULL first. If zget_command succeeds but returns NULL (edge case), this will cause a crash.

### CWE-377: Insecure Temporary File
- **Severity**: MEDIUM
- **Confidence**: 70%
- The cleanup_test_db function uses unlink() on FILENAME without verifying it's a safe test file. If FILENAME is user-controlled or points to a critical system file, this could lead to unauthorized file deletion.

### CWE-134: Use of Externally-Controlled Format String
- **Severity**: MEDIUM
- **Confidence**: 85%
- The test macro uses printf with a user-controlled format string (_s) without format specifiers. If _s contains format specifiers like %s or %n, it could lead to information disclosure or crashes.

### CWE-404: Improper Resource Shutdown or Release
- **Severity**: LOW
- **Confidence**: 70%
- free_cache() is called but the cache is never re-initialized before subsequent tests. This could cause use-after-free issues if other code attempts to access the freed cache.

### CWE-404: Improper Resource Shutdown or Release
- **Severity**: LOW
- **Confidence**: 60%
- The get_result pointer is freed after use, but if zget_command fails or returns an error, the pointer may not be properly initialized, potentially leading to a double-free or use-after-free if the error path also attempts cleanup.

### CWE-732: Incorrect Permission Assignment for Critical Resource
- **Severity**: LOW
- **Confidence**: 65%
- The test database file is created with permissions 0644 (world-readable). While this is a test file, it may contain sensitive test data that should not be readable by other users on the system.

### CWE-252: Unchecked Return Value
- **Severity**: LOW
- **Confidence**: 75%
- The return value of unlink() is not checked. If the file deletion fails, subsequent tests may operate on stale data, leading to incorrect test results or unexpected behavior.

---
*Automated by [deft.is](https://deft.is) code scanning*