### PR TITLE
[deft-security] Fix 5 vulnerabilities in src/io_benchmark.c

### DIFF
--- a/src/io_benchmark.c
+++ b/src/io_benchmark.c
@@ -23,7 +23,17 @@ static int read_item_from_benchmark_file(FILE *file, char **key, char **value) {
 
 int init_benchmark_db(const char *filename, int num_entries)
 {
-    srand(time(NULL));
+    // For security-sensitive applications, use a cryptographically secure RNG
+    // Example using /dev/urandom on Unix-like systems:
+    FILE *urandom = fopen("/dev/urandom", "rb");
+    unsigned int seed;
+    if (urandom) {
+        fread(&seed, sizeof(seed), 1, urandom);
+        fclose(urandom);
+        srand(seed);
+    } else {
+        srand(time(NULL)); // Fallback
+    }
     const int MIN_LENGTH = 4;
     const int MAX_LENGTH = 64;
 
@@ -95,6 +105,9 @@ char *find_key_in_benchmark_db(const char *filename, const char *key)
         free(current_key);
         free(current_value);
     }
+    // Clean up any remaining allocations if loop exited due to error
+    if (current_key) free(current_key);
+    if (current_value) free(current_value);
 
     fclose(file);
     return found_value;
@@ -130,6 +143,9 @@ char **get_all_keys_from_benchmark_db(const char *filename, int *num_keys)
             char **new_keys = realloc(keys, sizeof(char *) * capacity);
             if (!new_keys) {
                 perror("Failed to reallocate memory for keys");
+                // Free current iteration's allocations
+                free(current_key);
+                free(current_value);
                 // Free already allocated keys
                 for (int i = 0; i < count; i++) {
                     free(keys[i]);
@@ -145,6 +161,9 @@ char **get_all_keys_from_benchmark_db(const char *filename, int *num_keys)
         char *key_copy = my_strdup(current_key);
         if (!key_copy) {
             perror("Failed to allocate memory for key copy");
+            // Free current iteration's allocations
+            free(current_key);
+            free(current_value);
             // Free already allocated keys
             for (int i = 0; i < count; i++) {
                 free(keys[i]);
@@ -166,5 +185,8 @@ char **get_all_keys_from_benchmark_db(const char *filename, int *num_keys)
 
 void cleanup_benchmark_db(const char *filename)
 {
-    unlink(filename);
+    if (unlink(filename) != 0) {
+        perror("Failed to delete benchmark database file");
+        // Optionally return an error code
+    }
 }


### PR DESCRIPTION
## Security Fixes

**File**: `src/io_benchmark.c`
**Highest Severity**: MEDIUM
**Fixes Applied**: 5

### CWE-338: Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
- **Severity**: MEDIUM
- **Confidence**: 70%
- The code uses srand(time(NULL)) and rand() for generating benchmark data. While this is acceptable for non-security-critical benchmarking, if this data is used in any security context or if predictable data could affect security testing results, this is a vulnerability. An attacker could predict the sequence of generated keys/values.

### CWE-401: Missing Release of Memory in Error Path
- **Severity**: LOW
- **Confidence**: 90%
- In get_all_keys_from_benchmark_db, if my_strdup fails to allocate memory for key_copy, the function frees all previously allocated keys but doesn't free current_key and current_value from the current iteration before returning.

### CWE-401: Missing Release of Memory in Error Path
- **Severity**: LOW
- **Confidence**: 75%
- In get_all_keys_from_benchmark_db, when read_item_from_benchmark_file is called in the while loop, if it fails and returns <= 0, current_key and current_value might be partially allocated but not freed before the function returns. This depends on the implementation of read_item_from_benchmark_file.

### CWE-401: Missing Release of Memory in Error Path
- **Severity**: LOW
- **Confidence**: 60%
- In find_key_in_benchmark_db, if read_item_from_benchmark_file returns an error after allocating current_key or current_value but before the comparison, those allocations may not be freed. While the function likely handles this internally, if it returns an error with partially allocated memory, this creates a leak.

### CWE-252: Unchecked Return Value
- **Severity**: LOW
- **Confidence**: 85%
- The return value of unlink() is not checked. If the file deletion fails (due to permissions, file not existing, etc.), the function silently continues without notifying the caller. This could lead to resource leaks or unexpected behavior if the caller assumes the file was deleted.

---
*Automated by [deft.is](https://deft.is) code scanning*