### PR TITLE
[deft-security] Fix 4 vulnerabilities in src/cache.c

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -49,10 +49,12 @@ void add_to_cache(const char *key, const char *value)
 {
     pthread_mutex_lock(&cache_mutex);
     if (memory_cache == NULL) init_cache();
-    hash_table_insert(memory_cache, key, value);
-    // Update last_accessed for the item
-    DataItem *item = hash_table_search(memory_cache, key);
-    if (item) item->last_accessed = (unsigned int)time(NULL);
+    if (hash_table_insert(memory_cache, key, value) == 0) {
+        // Update last_accessed for the item
+        DataItem *item = hash_table_search(memory_cache, key);
+        if (item) item->last_accessed = (time_t)time(NULL);
+    }
+    if (item) item->last_accessed = (time_t)time(NULL);
     pthread_mutex_unlock(&cache_mutex);
 }
 
@@ -64,17 +66,21 @@ DataItem *get_from_cache(const char *key)
         return NULL;
     }
     DataItem* item = hash_table_search(memory_cache, key);
+    DataItem* result = NULL;
     if (item) {
-        if (time(NULL) - item->last_accessed > CACHE_TTL) {
+        if ((time_t)(time(NULL) - item->last_accessed) > CACHE_TTL) {
             remove_from_cache_internal(key);
             pthread_mutex_unlock(&cache_mutex);
             return NULL;
         }
         item->hit_count++;
-        item->last_accessed = (unsigned int)time(NULL);
+        item->last_accessed = (time_t)time(NULL);
+        // Return a deep copy or use reference counting
+        result = malloc(sizeof(DataItem));
+        if (result) memcpy(result, item, sizeof(DataItem));
     }
     pthread_mutex_unlock(&cache_mutex);
-    return item;
+    return result;
 }
 
 void remove_from_cache(const char *key)


### PR DESCRIPTION
## Security Fixes

**File**: `src/cache.c`
**Highest Severity**: MEDIUM
**Fixes Applied**: 4

### CWE-367: Time-of-check Time-of-use (TOCTOU) Race Condition
- **Severity**: MEDIUM
- **Confidence**: 88%
- The function get_from_cache() returns a pointer to a DataItem while releasing the mutex. Another thread could modify or delete this item after the mutex is unlocked but before the caller uses it, leading to use-after-free or data corruption.

### CWE-190: Integer Overflow or Wraparound
- **Severity**: MEDIUM
- **Confidence**: 90%
- Casting time(NULL) to unsigned int can cause integer overflow. The subtraction on line 63 (time(NULL) - item->last_accessed) will produce incorrect results when time_t is 64-bit and wraps around the unsigned int boundary.

### CWE-190: Integer Overflow or Wraparound
- **Severity**: MEDIUM
- **Confidence**: 92%
- Casting time(NULL) to unsigned int can cause integer overflow on systems where time_t is 64-bit (most modern systems). After year 2106, this will wrap around to 0, breaking cache expiration logic.

### CWE-476: NULL Pointer Dereference
- **Severity**: LOW
- **Confidence**: 75%
- If hash_table_insert() fails or hash_table_search() returns NULL after insertion (due to memory issues or hash collision handling), dereferencing item without checking could cause a crash. While unlikely, defensive programming should verify the pointer.

---
*Automated by [deft.is](https://deft.is) code scanning*